### PR TITLE
Initial support for Google Colaboratory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,10 +35,10 @@ let package = Package(
       name: "x10_optimizers_tensor_visitor_plan",
       type: .dynamic,
       targets: ["x10_optimizers_tensor_visitor_plan"]),
-    // .library(
-    //   name: "x10_training_loop",
-    //   type: .dynamic,
-    //   targets: ["x10_training_loop"]),
+    .library(
+      name: "x10_training_loop",
+      type: .dynamic,
+      targets: ["x10_training_loop"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
@@ -80,13 +80,13 @@ let package = Package(
         "swift_bindings/optimizers/Optimizer.swift",
         "swift_bindings/optimizers/Optimizers.swift",
       ]),
-    // .target(
-    //   name: "x10_training_loop",
-    //   dependencies: ["TensorFlow"],
-    //   path: "Sources/x10",
-    //   sources: [
-    //     "swift_bindings/training_loop.swift",
-    //   ]),
+    .target(
+      name: "x10_training_loop",
+      dependencies: ["TensorFlow"],
+      path: "Sources/x10",
+      sources: [
+        "swift_bindings/training_loop.swift",
+      ]),
     .target(
       name: "Experimental",
       dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -35,10 +35,10 @@ let package = Package(
       name: "x10_optimizers_tensor_visitor_plan",
       type: .dynamic,
       targets: ["x10_optimizers_tensor_visitor_plan"]),
-    .library(
-      name: "x10_training_loop",
-      type: .dynamic,
-      targets: ["x10_training_loop"]),
+    // .library(
+    //   name: "x10_training_loop",
+    //   type: .dynamic,
+    //   targets: ["x10_training_loop"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-numerics", .branch("main")),
@@ -80,13 +80,13 @@ let package = Package(
         "swift_bindings/optimizers/Optimizer.swift",
         "swift_bindings/optimizers/Optimizers.swift",
       ]),
-    .target(
-      name: "x10_training_loop",
-      dependencies: ["TensorFlow"],
-      path: "Sources/x10",
-      sources: [
-        "swift_bindings/training_loop.swift",
-      ]),
+    // .target(
+    //   name: "x10_training_loop",
+    //   dependencies: ["TensorFlow"],
+    //   path: "Sources/x10",
+    //   sources: [
+    //     "swift_bindings/training_loop.swift",
+    //   ]),
     .target(
       name: "Experimental",
       dependencies: [],

--- a/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorEvaluationTests.swift
@@ -82,6 +82,7 @@ final class LazyTensorEvaluationTests: LazyTensorTestCase {
   }
 
   func testNoOutputOperations() {
+    #if !FALLBACK_X10_BINARY
     withDevice(.cpu) {
       let elements1: Tensor<Int32> = [0, 1, 2]
       let elements2: Tensor<Int32> = [10, 11, 12]
@@ -111,6 +112,7 @@ final class LazyTensorEvaluationTests: LazyTensorTestCase {
       XCTAssertEqual(Tensor(handle: next.a).scalarized(), 0)
       XCTAssertEqual(Tensor(handle: next.b).scalarized(), 10)
     }
+    #endif
   }
 
   private func isMaterialized<T: TensorFlowScalar>(_ input: Tensor<T>) -> Bool {

--- a/Tests/TensorFlowTests/LazyTensorHandleTests.swift
+++ b/Tests/TensorFlowTests/LazyTensorHandleTests.swift
@@ -131,6 +131,7 @@ final class LazyTensorHandleTests: XCTestCase {
   }
 
   func testTensorToLazyTensorConversions() {
+    #if !FALLBACK_X10_BINARY
     checkConversions(Tensor<Float>(10.0))
     checkConversions(StringTensor("Hello!"))
 
@@ -150,6 +151,7 @@ final class LazyTensorHandleTests: XCTestCase {
     )
     checkConversions(dataset)
     checkConversions(iterator)
+    #endif
   }
 
   private func isSymbolic(_ t: LazyTensorHandle?) -> Bool {


### PR DESCRIPTION
Allows the head branch of Swift for TensorFlow to execute Swift package tests in a Google Colab environment. This means using the old TF 2.4 binary, which is slightly API-incompatible with TF 2.9. Some operators in the `_Raw` namespace (listed below) will cause a runtime crash. Nothing else in the public API should crash, unless it is deprecated.

- Operators with the `metadata` parameter. One example is `_Raw.tensorSliceDataset`, which was used in Swift package tests. To avoid this crash, add `-Xswiftc -DFALLBACK_X10_BINARY` when running tests with the old X10 binary.
- Operators whose generic parameter constraints changed when [upgrading raw bindings](https://github.com/s4tf/s4tf/pull/10) to TF 2.9. Several ops upgraded from `TensorFlowIndex` (`Int32` and `Int64`) to `TensorFlowInteger` (all Swift integer types).
- Operators added between TF 2.1 and TF 2.9.

I attempted to enable `x10_training_loop`, but couldn't because of an error described in https://github.com/tensorflow/swift-apis/pull/1177.