### PR TITLE
Allow compilation on recent nightly toolchains

### DIFF
--- a/Sources/TensorFlow/Core/CopyableToDevice.swift
+++ b/Sources/TensorFlow/Core/CopyableToDevice.swift
@@ -20,7 +20,7 @@
 /// - Note: this workaround is necessary because `CopyableToDevice` is a protocol with `Self`
 ///   requirements, so `x as? CopyableToDevice` does not work.
 public protocol _CopyableToDevice {
-  static func _move<Root>(
+  static func `_move`<Root>(
     _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>, to: Device)
 }
 
@@ -38,7 +38,7 @@ extension CopyableToDevice {
   ///
   /// - Note: Do not ever use this API directly. This is an implementation detail to support
   ///   `KeyPathIterable.move(to:)` and `KeyPathIterable.init(copying:to:)`.
-  public static func _move<Root>(
+  public static func `_move`<Root>(
     _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>, to device: Device
   ) {
     guard let keyPath = rootKeyPath as? WritableKeyPath<Root, Self> else {
@@ -53,15 +53,15 @@ extension CopyableToDevice {
 extension _KeyPathIterableBase {
   /// Recursively copies all `CopyableToDevice`-conforming nested properties and elements in `root`
   /// to the given `Device` in-place.
-  public func _move<Root>(
+  public func `_move`<Root>(
     _ root: inout Root, _ rootKeyPath: PartialKeyPath<Root>, to device: Device
   ) {
     for kp in _allKeyPathsTypeErased {
       let joinedKeyPath = rootKeyPath.appending(path: kp)!
       if let valueType = type(of: joinedKeyPath).valueType as? _CopyableToDevice.Type {
-        valueType._move(&root, joinedKeyPath, to: device)
+        valueType.`_move`(&root, joinedKeyPath, to: device)
       } else if let value = self[keyPath: kp], let nested = value as? _KeyPathIterableBase {
-        nested._move(&root, joinedKeyPath, to: device)
+        nested.`_move`(&root, joinedKeyPath, to: device)
       }
     }
   }
@@ -71,7 +71,7 @@ extension KeyPathIterable {
   /// Recursively copies all `CopyableToDevice`-conforming nested properties and elements to the
   /// given `Device` in-place.
   public mutating func move(to device: Device) {
-    _move(&self, \.self, to: device)
+    `_move`(&self, \.self, to: device)
   }
 
   /// Creates a copy of `self` with all `CopyableToDevice`-conforming nested properties and elements

--- a/Sources/TensorFlow/Layers/Morphological.swift
+++ b/Sources/TensorFlow/Layers/Morphological.swift
@@ -16,7 +16,7 @@
 ///
 /// This layer returns the morphogical dilation of the input tensor with the provided filters
 @frozen
-public struct `Dilation2D`<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct Dilation2D<Scalar: TensorFlowFloatingPoint>: Layer {
   /// The 4-D dilation filter.
   public var filter: Tensor<Scalar>
   /// The strides of the sliding window for spatial dimensions.
@@ -86,7 +86,7 @@ public struct `Dilation2D`<Scalar: TensorFlowFloatingPoint>: Layer {
 ///
 /// This layer returns the morphogical erosion of the input tensor with the provided filters
 @frozen
-public struct `Erosion2D`<Scalar: TensorFlowFloatingPoint>: Layer {
+public struct Erosion2D<Scalar: TensorFlowFloatingPoint>: Layer {
   /// The 4-D dilation filter.
   public var filter: Tensor<Scalar>
   /// The strides of the sliding window for spatial dimensions.

--- a/Sources/x10/swift_bindings/Device.swift
+++ b/Sources/x10/swift_bindings/Device.swift
@@ -46,7 +46,7 @@ extension Array where Element == Device {
 
 /// A device on which `Tensor`s can be allocated.
 public struct Device {
-  /// The device kind: GPU, GPU, TPU, or remote TPU.
+  /// The device kind: CPU, GPU, TPU, or remote TPU.
   public let kind: Kind
 
   /// The device ordinal value.


### PR DESCRIPTION
Workaround for https://github.com/apple/swift/issues/60492. Although this bug may be resolved in the future, adding backticks to `_move` will not harm anything. It enables compilation on the 2022-08-09 toolchain, in case anyone wants to use that toolchain in the future.

Notes:
- Includes some typos fixed in https://github.com/s4tf/s4tf/pull/19. That pull request should now have merge conflicts, but it's already becoming unmaintained. Getting XLA/LazyTensor to work is not in my self-interest right now.

Tested on macOS:
- macOS 12.5
- arm64
- TensorFlow 2.9.1
- Swift 2022-08-09 Development Snapshot

Tested on Colab: 
- Ubuntu 18.04
- x86_64
- TensorFlow 2.4.0 (fallback X10 binary)
- Swift 2022-08-09 Development Snapshot